### PR TITLE
remove typo in geo coordinates

### DIFF
--- a/public/data/freibaeder.kml
+++ b/public/data/freibaeder.kml
@@ -188,7 +188,7 @@
       "http://www.berlinerbaederbetriebe.de/116.html" 
     </description>
     <Point>
-      <coordinates>13.41637,152.4797,0</coordinates>
+      <coordinates>13.41637,52.4797,0</coordinates>
     </Point>
   </Placemark> 
 <Placemark>


### PR DESCRIPTION
I removed the typo in the coordinates section of the Sommerbad Neukölln.
corresponding issue can be found [here](https://github.com/MagdaN/berliner-badestellen/issues/6)