### PR TITLE
fix Open Graph Protocol metadata (not tested)

### DIFF
--- a/public/info.html
+++ b/public/info.html
@@ -6,8 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
     <meta property="og:title" content="Berliner Badeseen" />
-    <meta property="og:url" content="http://mamanoke.de/badessen" />
-    <meta property="og:image" content="http://mamanoke.de/badessen"/>
+    <meta property="og:url" content="https://berlin.codefor.de/badestellen/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://berlin.codefor.de/badestellen/img/blau.png"/>
 
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
 


### PR DESCRIPTION
The OGP metadata had a wrong values for `og:url` and `og:image`, and no value for `og:type`.